### PR TITLE
Adopt Jekyll core plugins practices

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,23 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.1
+  Include:
+    - lib/**/*.rb
+    - test/*.rb
+    - Gemfile
+    - Rakefile
+    - jekyll-microtypo.gemspec
+
+  Exclude:
+    - .gitignore
+    - .rubocop.yml
+    - Gemfile.lock
+    - LICENSE
+    - README.md
+    - vendor/**/*
+
+Metrics/LineLength:
+  Exclude:
+    - test/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in jekyll-post-files.gemspec
 gemspec

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Boris Schapira
+Copyright (c) 2016-present Boris Schapira and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,24 @@
+# frozen_string_literal: true
+
+require "rubygems"
+require "bundler"
 require "bundler/gem_tasks"
-require 'rake/testtask'
 
-task :default => :spec
-
-Rake::TestTask.new do |t|
-	t.libs << 'test'
+begin
+  Bundler.setup(:default, :development, :test)
+rescue Bundler::BundlerError => e
+  warn e.message
+  warn "Run `bundle install` to install missing gems"
+  exit e.status_code
 end
+
+require "rake"
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |test|
+  test.libs << "lib" << "test"
+  test.pattern = "test/test_*.rb"
+  test.warning = false
+end
+
+task :default => :test

--- a/jekyll-microtypo.gemspec
+++ b/jekyll-microtypo.gemspec
@@ -1,4 +1,6 @@
-$LOAD_PATH.unshift(File.expand_path("../lib", __FILE__))
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("lib", __dir__))
 require "jekyll/microtypo/version"
 
 Gem::Specification.new do |spec|
@@ -16,13 +18,13 @@ Gem::Specification.new do |spec|
     Jekyll plugin that improves microtypography
   DESC
 
-  spec.rubygems_version = '2.2.2'
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = ">= 2.1.0"
+  spec.rubygems_version = "2.2.2"
 
   spec.add_runtime_dependency "jekyll", ">= 3.0", "< 4.0"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rubocop", "~> 0.49.0"
+  spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "minitest", "~> 5.8", ">= 5.8.4"
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rubocop", "~> 0.51.0"
 end

--- a/lib/jekyll-microtypo.rb
+++ b/lib/jekyll-microtypo.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "jekyll/microtypo"

--- a/lib/jekyll/microtypo.rb
+++ b/lib/jekyll/microtypo.rb
@@ -1,97 +1,99 @@
+# frozen_string_literal: true
+
 module Jekyll
-    module Microtypo
-        # Example:
-        #   {{ content | microtypo: "fr_FR" }}
-        def microtypo(input, locale = nil)
-            locale = 'en_US'.freeze unless locale
+  module Microtypo
+      # Example:
+      #   {{ content | microtypo: "fr_FR" }}
+      def microtypo(input, locale = nil)
+          locale ||= 'en_US'.freeze
 
-            arrayResponse = []
+          arrayResponse = []
 
-            # <pre></pre> management
-            # Replace \n in <pre> by <br />\n in order to keep line break visualy
-            preArray = input.to_s.split('<pre'.freeze)
-            preArray.each do |input|
-                endPreArray = input.to_s.split('</pre>'.freeze)
-                if endPreArray.size == 2
-                    arrayResponse.push('<pre'.freeze)
-                    arrayResponse.push(endPreArray.first)
-                    arrayResponse.push('</pre>'.freeze)
-                end
-                input = endPreArray.last
+          # <pre></pre> management
+          # Replace \n in <pre> by <br />\n in order to keep line break visualy
+          preArray = input.to_s.split("<pre".freeze)
+          preArray.each do |input|
+              endPreArray = input.to_s.split("</pre>".freeze)
+              if endPreArray.size == 2
+                  arrayResponse.push("<pre".freeze)
+                  arrayResponse.push(endPreArray.first)
+                  arrayResponse.push("</pre>".freeze)
+              end
+              input = endPreArray.last
 
-                # <!-- nomicrotypo --><!-- endnomicrotypo --> management
-                noFixCommentArray = input.to_s.split('<!-- nomicrotypo -->'.freeze)
-                noFixCommentArray.each do |input|
-                    endNoFixCommentArray = input.to_s.split('<!-- endnomicrotypo -->'.freeze)
-                    if endNoFixCommentArray.size == 2
-                        arrayResponse.push(endNoFixCommentArray.first)
-                    end
-                    input = endNoFixCommentArray.last
+              # <!-- nomicrotypo --><!-- endnomicrotypo --> management
+              noFixCommentArray = input.to_s.split("<!-- nomicrotypo -->".freeze)
+              noFixCommentArray.each do |input|
+                  endNoFixCommentArray = input.to_s.split("<!-- endnomicrotypo -->".freeze)
+                  if endNoFixCommentArray.size == 2
+                      arrayResponse.push(endNoFixCommentArray.first)
+                  end
+                  input = endNoFixCommentArray.last
 
-                    # <script></script> management
-                    scriptArray = input.to_s.split('<script'.freeze)
-                    scriptArray.each do |input|
-                        endScriptArray = input.to_s.split('</script>'.freeze)
-                        if endScriptArray.size == 2
-                            arrayResponse.push('<script'.freeze)
-                            arrayResponse.push(endScriptArray.first)
-                            arrayResponse.push('</script>'.freeze)
-                        end
-                        input = endScriptArray.last
+                  # <script></script> management
+                  scriptArray = input.to_s.split("<script".freeze)
+                  scriptArray.each do |input|
+                      endScriptArray = input.to_s.split("</script>".freeze)
+                      if endScriptArray.size == 2
+                          arrayResponse.push("<script".freeze)
+                          arrayResponse.push(endScriptArray.first)
+                          arrayResponse.push("</script>".freeze)
+                      end
+                      input = endScriptArray.last
 
-                        if locale == 'fr_FR'
+                      if locale == "fr_FR"
 
-                            # 1er, 3ème, 4ème…
-                            input.gsub!(/(\d)(e|è)(r|me)?([\s.,])/, '\1<sup>\2\3</sup>\4'.freeze)
+                          # 1er, 3ème, 4ème…
+                          input.gsub!(%r!(\d)(e|è)(r|me)?([\s.,])!, '\1<sup>\2\3</sup>\4'.freeze)
 
-                            # Guillemets à la française
-                            input.gsub!(/(&ldquo;|“|«)(\s|&nbsp;| )*/, '«&#8239;'.freeze)
-                            input.gsub!(/(\s|&nbsp;| )*(&rdquo;|”|»)/, '&#8239;»'.freeze)
+                          # Guillemets à la française
+                          input.gsub!(%r!(&ldquo;|“|«)(\s|&nbsp;| )*!, "«&#8239;".freeze)
+                          input.gsub!(%r!(\s|&nbsp;| )*(&rdquo;|”|»)!, "&#8239;»".freeze)
 
-                            # Special punctuation
-                            input.gsub!(/ \?\!([^\w]|$)/, '&#8239;&#8264;\1'.freeze)
-                            input.gsub!(/ \!\?([^\w]|$)/, '&#8239;&#8265;\1'.freeze)
-                            input.gsub!(/ \!\!\!([^\w]|$)/, '&#8239;&#8252;\1'.freeze)
-                            input.gsub!(/ \!\!([^\w]|$)/, '&#8239;&#8252;\1'.freeze)
+                          # Special punctuation
+                          input.gsub!(%r! \?\!([^\w]|$)!, '&#8239;&#8264;\1'.freeze)
+                          input.gsub!(%r! \!\?([^\w]|$)!, '&#8239;&#8265;\1'.freeze)
+                          input.gsub!(%r! \!\!\!([^\w]|$)!, '&#8239;&#8252;\1'.freeze)
+                          input.gsub!(%r! \!\!([^\w]|$)!, '&#8239;&#8252;\1'.freeze)
 
-                            # Thin non-breaking space before '%', ';', '!', '?', 'px'
-                            input.gsub!(/(\s)+(\d+)(\s)?(px|%)(\s|.)/, '\1\2&#8239;\4\5'.freeze)
-                            input.gsub!(/ (%|;|\!|\?)([^\w!]|$)/, '&#8239;\1\2'.freeze)
+                          # Thin non-breaking space before '%', ';', '!', '?', 'px'
+                          input.gsub!(%r!(\s)+(\d+)(\s)?(px|%)(\s|.)!, '\1\2&#8239;\4\5'.freeze)
+                          input.gsub!(%r! (%|;|\!|\?)([^\w!]$)!, '&#8239;\1\2'.freeze)
 
-                            # non-breaking space
-                            input.gsub!(' :'.freeze, '&nbsp;:'.freeze)
+                          # non-breaking space
+                          input.gsub!(" :".freeze, "&nbsp;:".freeze)
 
-                            # Currencies
-                            input.gsub!(/(\d+)\s*($|€)/, '\1&nbsp;\2'.freeze)
+                          # Currencies
+                          input.gsub!(%r!(\d+)\s*($|€)!, '\1&nbsp;\2'.freeze)
 
-                            # nbsp after middle dash (dialogs)
-                            input.gsub!(/(—|&mdash;)(\s)/, '\1&nbsp;'.freeze)
+                          # nbsp after middle dash (dialogs)
+                          input.gsub!(%r!(—|&mdash;)(\s)!, '\1&nbsp;'.freeze)
 
-                            # Times
-                            input.gsub!(/(\s)+(\d+)(\s)*x(\s)*(?=\d)/, '\1\2&nbsp;&times;&nbsp;\5'.freeze)
+                          # Times
+                          input.gsub!(%r!(\s)+(\d+)(\s)*x(\s)*(?=\d)!, '\1\2&nbsp;&times;&nbsp;\5'.freeze)
 
-                        elsif locale == 'en_US'
+                      elsif locale == "en_US"
 
-                            # Remove useless spaces
-                            input.gsub!(/ (:|%|;|\!|\?)([^\w!]|$)/, '\1\2'.freeze)
+                          # Remove useless spaces
+                          input.gsub!(%r! (:|%|;|\!|\?)([^\w!]|$)!, '\1\2'.freeze)
 
-                            # Currencies
-                            input.gsub!(/($|€)\s*(\d+)/, '\1\2'.freeze)
+                          # Currencies
+                          input.gsub!(%r!($|€)\s*(\d+)!, '\1\2'.freeze)
 
-                        end
+                      end
 
-                        # Elipsis
-                        input.gsub!('...', '&#8230;'.freeze)
+                      # Elipsis
+                      input.gsub!("...", "&#8230;".freeze)
 
-                        arrayResponse.push input
-                    end
-                end
-            end
+                      arrayResponse.push input
+                  end
+              end
+          end
 
-            # Clean empty lines
-            arrayResponse.join.gsub(/\A\s*\n$/, ''.freeze)
-        end
-    end
+          # Clean empty lines
+          arrayResponse.join.gsub(%r!\A\s*\n$!, "".freeze)
+      end
+  end
 end
 
 Liquid::Template.register_filter(Jekyll::Microtypo)

--- a/lib/jekyll/microtypo/version.rb
+++ b/lib/jekyll/microtypo/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   module Microtypo
     VERSION = "0.0.9".freeze

--- a/test/test_microtypo.rb
+++ b/test/test_microtypo.rb
@@ -1,46 +1,59 @@
-require 'minitest/autorun'
-require 'liquid'
-require 'jekyll/microtypo'
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "liquid"
+require "jekyll/microtypo"
 
 include Jekyll::Microtypo
 
 class MicrotypoTest < Minitest::Test
-	def test_all__comment
-		assert_equal "Before One ! After", Jekyll::Microtypo.microtypo("Before <!-- nomicrotypo -->One !<!-- endnomicrotypo --> After")
-		assert_equal "Avant Hey! Après", Jekyll::Microtypo.microtypo("Avant <!-- nomicrotypo -->Hey!<!-- endnomicrotypo --> Après")
-	end
-	def test_all__pre_script_nofix
-		assert_equal 'A!<pre>B !</pre> C!<script>D !</script> E!', Jekyll::Microtypo.microtypo('A !<pre>B !</pre> C !<script>D !</script> E !')
-		assert_equal 'A&#8239;!<pre>B !</pre> C&#8239;!<script>D !</script> E&#8239;!', Jekyll::Microtypo.microtypo('A !<pre>B !</pre> C !<script>D !</script> E !', 'fr_FR')
-	end
-	def test_fr_Fr__thin_nb_space
-		assert_equal 'Hello&#8239;! 4&#8239;px, 5&#8239;%&#8239;?', Jekyll::Microtypo.microtypo('Hello ! 4 px, 5 % ?', 'fr_FR')
-	end
-	def test_fr_Fr__elipsis
-		assert_equal 'Moi ça va&#8230;', Jekyll::Microtypo.microtypo('Moi ça va...', 'fr_FR')
-	end
-	def test_fr_Fr__ordinal
-		assert_equal 'Si je double le 2<sup>ème</sup>, je deviens 1<sup>er</sup>.', Jekyll::Microtypo.microtypo('Si je double le 2ème, je deviens 1er.', 'fr_FR')
-	end
-	def test_fr_Fr__frenchquotes
-		assert_equal 'On dit «&#8239;en Avignon&#8239;», pas «&#8239;à Avignon&#8239;». Ah, comme dans «&#8239;en Carmélie&#8239;» alors.', Jekyll::Microtypo.microtypo('On dit &ldquo;en Avignon&rdquo;, pas “à Avignon”. Ah, comme dans «&nbsp;en Carmélie » alors.', 'fr_FR')
-	end
-	def test_fr_Fr__specialpunc
-		assert_equal 'Non&#8239;&#8264; Si&#8239;&#8252; Je ne te crois pas&#8239;&#8265; Je te jure&#8239;&#8252;', Jekyll::Microtypo.microtypo('Non ?! Si !! Je ne te crois pas !? Je te jure !!!', 'fr_FR')
-	end
-	def test_fr_Fr__nbsp
-		assert_equal "2001&nbsp;: l'odysée de l'espace", Jekyll::Microtypo.microtypo("2001 : l'odysée de l'espace", 'fr_FR')
-	end
-	def test_fr_Fr__currencies
-		assert_equal "599$, donc 599&nbsp;€", Jekyll::Microtypo.microtypo("599$, donc 599 €", 'fr_FR')
-	end
-	def test_fr_Fr__multiply
-		assert_equal "C'est un poster en 4&nbsp;&times;&nbsp;3.", Jekyll::Microtypo.microtypo("C'est un poster en 4x3.", 'fr_FR')
-	end
-	def test_en_US__removespaces
-		assert_equal "So: what are you thinking? Either you're in at 100% or you're out.", Jekyll::Microtypo.microtypo("So : what are you thinking ? Either you're in at 100 % or you're out.", 'en_US')
-	end
-	def test_en_US__currencies
-		assert_equal "$599, so €599", Jekyll::Microtypo.microtypo("$599, so € 599", 'en_US')
-	end
+  def test_all_comment
+    assert_equal "Before One ! After", Jekyll::Microtypo.microtypo("Before <!-- nomicrotypo -->One !<!-- endnomicrotypo --> After")
+    assert_equal "Avant Hey! Après", Jekyll::Microtypo.microtypo("Avant <!-- nomicrotypo -->Hey!<!-- endnomicrotypo --> Après")
+  end
+
+  def test_all_pre_script_nofix
+    assert_equal "A!<pre>B !</pre> C!<script>D !</script> E!", Jekyll::Microtypo.microtypo("A !<pre>B !</pre> C !<script>D !</script> E !")
+    assert_equal "A&#8239;!<pre>B !</pre> C&#8239;!<script>D !</script> E&#8239;!", Jekyll::Microtypo.microtypo("A !<pre>B !</pre> C !<script>D !</script> E !", "fr_FR")
+  end
+
+  def test_fr_fr_thin_nb_space
+    assert_equal "Hello&#8239;! 4&#8239;px, 5&#8239;%&#8239;?", Jekyll::Microtypo.microtypo("Hello ! 4 px, 5 % ?", "fr_FR")
+  end
+
+  def test_fr_fr_elipsis
+    assert_equal "Moi ça va&#8230;", Jekyll::Microtypo.microtypo("Moi ça va...", "fr_FR")
+  end
+
+  def test_fr_fr_ordinal
+    assert_equal "Si je double le 2<sup>ème</sup>, je deviens 1<sup>er</sup>.", Jekyll::Microtypo.microtypo("Si je double le 2ème, je deviens 1er.", "fr_FR")
+  end
+
+  def test_fr_fr_frenchquotes
+    assert_equal "On dit «&#8239;en Avignon&#8239;», pas «&#8239;à Avignon&#8239;». Ah, comme dans «&#8239;en Carmélie&#8239;» alors.", Jekyll::Microtypo.microtypo("On dit &ldquo;en Avignon&rdquo;, pas “à Avignon”. Ah, comme dans «&nbsp;en Carmélie » alors.", "fr_FR")
+  end
+
+  def test_fr_fr_specialpunc
+    assert_equal "Non&#8239;&#8264; Si&#8239;&#8252; Je ne te crois pas&#8239;&#8265; Je te jure&#8239;&#8252;", Jekyll::Microtypo.microtypo("Non ?! Si !! Je ne te crois pas !? Je te jure !!!", "fr_FR")
+  end
+
+  def test_fr_fr_nbsp
+    assert_equal "2001&nbsp;: l'odysée de l'espace", Jekyll::Microtypo.microtypo("2001 : l'odysée de l'espace", "fr_FR")
+  end
+
+  def test_fr_fr_currencies
+    assert_equal "599$, donc 599&nbsp;€", Jekyll::Microtypo.microtypo("599$, donc 599 €", "fr_FR")
+  end
+
+  def test_fr_fr_multiply
+    assert_equal "C'est un poster en 4&nbsp;&times;&nbsp;3.", Jekyll::Microtypo.microtypo("C'est un poster en 4x3.", "fr_FR")
+  end
+
+  def test_en_us_removespaces
+    assert_equal "So: what are you thinking? Either you're in at 100% or you're out.", Jekyll::Microtypo.microtypo("So : what are you thinking ? Either you're in at 100 % or you're out.", "en_US")
+  end
+
+  def test_en_us_currencies
+    assert_equal "$599, so €599", Jekyll::Microtypo.microtypo("$599, so € 599", "en_US")
+  end
 end


### PR DESCRIPTION
This PR intends to adopt some common practices from jekyll core plugins:

- Lint Ruby with Rubocop (inherit from Jekyll's configuration)
- use `__dir__` 

Rubocop still detects two offenses:

```
❯ rubocop
Inspecting 7 files
....F..

Offenses:

lib/jekyll/microtypo.rb:61:39: E: premature end of char-class: / (%|;|!|\?)([^\w/
(Using Ruby 2.1 parser; configure using TargetRubyVersion parameter, under AllCops)
                          input.gsub!(%r! (%|;|\!|\?)([^\w!]$)!, '&#8239;\1\2'.freeze)
                                      ^^^^^^^^^^^^^^^^^^^^^
lib/jekyll/microtypo.rb:61:61: F: unexpected $'
(Using Ruby 2.1 parser; configure using TargetRubyVersion parameter, under AllCops`)
                          input.gsub!(%r! (%|;|\!|\?)([^\w!]$)!, '&#8239;\1\2'.freeze)
                                                            ^
7 files inspected, 2 offenses detected
```

The same error prevents the tests from completing:

```
❯ rake
/Users/frank/code/jekyll/plugins/jekyll-microtypo/test/test_microtypo.rb:5:in `require': /Users/frank/code/jekyll/plugins/jekyll-microtypo/lib/jekyll/microtypo.rb:61: premature end of char-class: / (%|;|!|\?)([^\w/ (SyntaxError)
/Users/frank/code/jekyll/plugins/jekyll-microtypo/lib/jekyll/microtypo.rb:61: syntax error, unexpected ']', expecting ')'
t.gsub!(%r! (%|;|\!|\?)([^\w!]$)!, '&#8239;\1\2'.freeze)
                              ^
/Users/frank/code/jekyll/plugins/jekyll-microtypo/lib/jekyll/microtypo.rb:61: `$)' is not allowed as a global variable name
...
```