### PR TITLE
Optimize Microtypo to improve memory usage

### DIFF
--- a/lib/jekyll/microtypo.rb
+++ b/lib/jekyll/microtypo.rb
@@ -33,10 +33,14 @@ module Jekyll
 
     def recursive_parser(input, locale, bucket, index)
       input = input.to_s
-      return fix_microtypo(input, locale, bucket) if index.zero?
+      return fix_microtypo(+input, locale, bucket) if index.zero?
 
       index -= 1
       head, tail, flag = QUEUE[index]
+
+      unless input.include?(head) && input.include?(tail)
+        return recursive_parser(input, locale, bucket, index)
+      end
 
       input.split(head).each do |item|
         item = item.to_s


### PR DESCRIPTION
  * redefine `array_exclude` into a private constant `QUEUE`.
  * refactor #recursive_parser to iterate through QUEUE instead of popping.
  * set up `settings` only when needed.
  * rename `array_response` into `bucket`.
  * remove unused method parameters from private methods.
  * fix minor bugs in a few regular expressions.